### PR TITLE
Index plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "gatsbyjs",
     "twitch"
   ],


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search. 

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310